### PR TITLE
Fix for code block indention issue

### DIFF
--- a/motion.py
+++ b/motion.py
@@ -83,11 +83,10 @@ class Notion:
             self.driver.get("https://notion.so" + url)
         time.sleep(wait)
         self.dom = BeautifulSoup(driver.page_source, "html.parser")
-        self.source = self.driver.page_source
+        self.source = self.driver.page_source.replace('</span>', '</span>!(notion)!')
         self.wait_spinner()
         self.divs = [d for d in self.dom.find_all("div") if d.has_attr("data-block-id")]
         self.links = set()
-        self.code_block = []
         if not options:
             options = {}
         self.options = options
@@ -107,7 +106,7 @@ class Notion:
             i += 1
             print("Waiting for spinner... " + str(i))
             time.sleep(1)
-            self.dom = BeautifulSoup(self.driver.page_source, "html.parser")
+            self.dom = BeautifulSoup(self.driver.page_source.replace('</span>', '</span>!(notion)!'), "html.parser")
             self.source = self.driver.page_source
 
     def init_site(self):
@@ -135,7 +134,7 @@ class Notion:
         except:
             time.sleep(2)
             print("Exception occurred, sleep for 2 secs and retry...")
-            self.dom = BeautifulSoup(self.driver.page_source, "html.parser")
+            self.dom = BeautifulSoup(self.driver.page_source.replace('</span>', '</span>!(notion)!'), "html.parser")
             if no_retry:
                 print(self.dom)
                 raise
@@ -153,17 +152,7 @@ class Notion:
 
     def gen_html(self):
         s = str(self.dom)
-        d_source = pq(self.source)
-        print('d_source')
-        print(d_source)
-        print(len(self.source))
-        for div_id in self.code_block:
-            print('Processing code block: ', div_id)
-            selector = 'div[data-block-id="' + div_id + '"]'
-            print(d_source(selector).html())
-            # tmp = d_source(selector).outer_html().replace(' data-block-id=', ' id=')
-            # s = s.replace('<' + div_id + '>', tmp)
-        self.html = s
+        self.html = s.replace('</span>!(notion)!', '</span>')
 
     def clean(self):
         cursor_div = self.dom.find(class_='notion-cursor-listener')
@@ -225,10 +214,6 @@ class Notion:
                 print(inner_html)
                 print('----------------------')
                 print(div)
-                continue
-            if div.find('span', class_='token'):
-                self.code_block.append(div["id"])
-                div.replace_with('<' + div['id'] + '>')
                 continue
             # For lightGallery.js
             img = div.find('img')

--- a/motion.py
+++ b/motion.py
@@ -182,9 +182,11 @@ class Notion:
             if text == '/*':
                 in_comment = True
                 div.decompose()
+                continue
             if text == '*/':
                 in_comment = False
                 div.decompose()
+                continue
             if in_comment:
                 div.decompose()
                 continue
@@ -192,9 +194,11 @@ class Notion:
             if text == '[html]':
                 in_html = True
                 div.decompose()
+                continue
             if text == '[/html]':
                 in_html = False
                 div.decompose()
+                continue
             if in_html:
                 div.replace_with(BeautifulSoup(div.text, "html.parser"))
                 continue

--- a/motion.py
+++ b/motion.py
@@ -196,7 +196,7 @@ class Notion:
                 in_html = False
                 div.decompose()
             if in_html:
-                div.replace_with(BeautifulSoup(div.text), "html.parser")
+                div.replace_with(BeautifulSoup(div.text, "html.parser"))
                 continue
             # For lightGallery.js
             img = div.find('img')

--- a/motion.py
+++ b/motion.py
@@ -218,13 +218,12 @@ class Notion:
                 div.decompose()
                 continue
             if in_html:
-                inner_html = BeautifulSoup(div.text.strip('HTML'), "html.parser")
+                inner_html = BeautifulSoup(div.text, "html.parser")
                 div.replace_with(inner_html)
                 print('Custom HTML inserted: ')
                 print('----------------------')
-                print(inner_html)
-                print('----------------------')
                 print(div)
+                print('----------------------')
                 continue
             if div.find('span', class_='token'):
                 self.code_block.append(div["id"])

--- a/motion.py
+++ b/motion.py
@@ -152,6 +152,13 @@ class Notion:
             f.write(self.source)
         with open(local_filename + '-bs.html', "w") as f:
             f.write(str(BeautifulSoup(self.source, 'lxml')))
+        # a solution
+        import re
+
+        def clean_line(line):
+            return re.sub(r'[ ]{2,}', ' ', re.sub(r'[\r\n]', '', line))
+        with open(local_filename + '-fix.html', "w") as f:
+            f.write(''.join([clean_line(line) for line in self.dom.findAll(text=True)]))
 
     def clean(self):
         cursor_div = self.dom.find(class_='notion-cursor-listener')

--- a/motion.py
+++ b/motion.py
@@ -106,6 +106,7 @@ class Notion:
             print("Waiting for spinner... " + str(i))
             time.sleep(1)
             self.dom = BeautifulSoup(self.driver.page_source, "html.parser")
+            self.source = self.driver.page_source
 
     def init_site(self):
         for f in assets:
@@ -144,8 +145,10 @@ class Notion:
         else:
             local_filename = "site/" + self.filename
         md(local_filename)
-        with open(local_filename, "wb") as f:
-            f.write(self.dom.prettify("utf-8"))
+        with open(local_filename, "w") as f:
+            f.write(self.dom)
+        with open(local_filename + '.raw', "w") as f:
+            f.write(self.source)
 
     def clean(self):
         cursor_div = self.dom.find(class_='notion-cursor-listener')

--- a/motion.py
+++ b/motion.py
@@ -200,12 +200,13 @@ class Notion:
                 div.decompose()
                 continue
             if in_html:
-                inner_html = BeautifulSoup(div.text, "html.parser")
+                inner_html = BeautifulSoup(div.text.strip('HTML'), "html.parser")
                 div.replace_with(inner_html)
                 print('Custom HTML inserted: ')
                 print('----------------------')
-                print(div)
+                print(inner_html)
                 print('----------------------')
+                print(div)
                 continue
             # For lightGallery.js
             img = div.find('img')

--- a/motion.py
+++ b/motion.py
@@ -151,7 +151,7 @@ class Notion:
         with open(local_filename + '-raw.html', "w") as f:
             f.write(self.source)
         with open(local_filename + '-bs.html', "w") as f:
-            f.write(str(BeautifulSoup(self.source, 'html.parser')))
+            f.write(str(BeautifulSoup(self.source, 'lxml')))
 
     def clean(self):
         cursor_div = self.dom.find(class_='notion-cursor-listener')

--- a/motion.py
+++ b/motion.py
@@ -200,7 +200,12 @@ class Notion:
                 div.decompose()
                 continue
             if in_html:
-                div.replace_with(BeautifulSoup(div.text, "html.parser"))
+                inner_html = BeautifulSoup(div.text, "html.parser")
+                div.replace_with(inner_html)
+                print('Custom HTML inserted: ')
+                print('----------------------')
+                print(div)
+                print('----------------------')
                 continue
             # For lightGallery.js
             img = div.find('img')

--- a/motion.py
+++ b/motion.py
@@ -133,6 +133,7 @@ class Notion:
             print("Exception occurred, sleep for 2 secs and retry...")
             self.dom = BeautifulSoup(self.driver.page_source, "html.parser")
             if no_retry:
+                print(self.dom)
                 raise
             else:
                 self.mod(no_retry=True)
@@ -162,7 +163,6 @@ class Notion:
         intercom_css = self.dom.find('style', id_="intercom-stylesheet")
         if intercom_css:
             intercom_css.decompose()
-
 
 
     def disqus(self):

--- a/motion.py
+++ b/motion.py
@@ -144,7 +144,7 @@ class Notion:
         else:
             local_filename = "site/" + self.filename
         md(local_filename)
-        with open(local_filename, "w") as f:
+        with open(local_filename, "wb") as f:
             f.write(self.dom.prettify("utf-8"))
 
     def clean(self):

--- a/motion.py
+++ b/motion.py
@@ -218,12 +218,13 @@ class Notion:
                 div.decompose()
                 continue
             if in_html:
-                inner_html = BeautifulSoup(div.text, "html.parser")
+                inner_html = BeautifulSoup(div.text.strip('HTML'), "html.parser")
                 div.replace_with(inner_html)
                 print('Custom HTML inserted: ')
                 print('----------------------')
-                print(div)
+                print(inner_html)
                 print('----------------------')
+                print(div)
                 continue
             if div.find('span', class_='token'):
                 self.code_block.append(div["id"])

--- a/motion.py
+++ b/motion.py
@@ -40,12 +40,12 @@ def motion(is_mobile=False):
     driver.quit()
 
 
-def download_file(url, local_filename):
+def download_file(url, local_filename, overwrite=False):
     # https://stackoverflow.com/questions/16694907/how-to-download-large-file-in-python-with-requests-py#16696317
     if local_filename.startswith("/"):
         local_filename = local_filename[1:]
     local_filename = "site/" + local_filename
-    if exists(local_filename):
+    if exists(local_filename) and not overwrite:
         print("File " + local_filename + " found. Skipping.")
         return
     md(local_filename)
@@ -115,7 +115,7 @@ class Notion:
         if 'apple_touch_icon' in self.options:
             download_file(self.options['apple_touch_icon'], 'images/logo-ios.png')
         if 'atom' in self.options:
-            download_file(self.options['atom'], 'feed')
+            download_file(self.options['atom'], 'feed', overwrite=True)
 
     def mod(self, no_retry=False):
         try:
@@ -269,6 +269,7 @@ class Notion:
         self.dom.find('head').append(new_tag)
         if 'atom' in self.options:
             atom = self.dom.new_tag('link', rel='alternate', type="application/rss+xml", href="/feed")
+        self.dom.find('head').append(atom)
         print("Title: " + self.dom.find("title").string)
         imgs = [i for i in self.dom.find_all('img') if i.has_attr(
             "style") and "30vh" in i["style"]]

--- a/motion.py
+++ b/motion.py
@@ -150,6 +150,8 @@ class Notion:
             f.write(str(self.dom))
         with open(local_filename + '-raw.html', "w") as f:
             f.write(self.source)
+        with open(local_filename + '-bs.html', "w") as f:
+            f.write(str(BeautifulSoup(self.source, 'html.parser')))
 
     def clean(self):
         cursor_div = self.dom.find(class_='notion-cursor-listener')

--- a/motion.py
+++ b/motion.py
@@ -147,17 +147,17 @@ class Notion:
         else:
             local_filename = "site/" + self.filename
         md(local_filename)
+        s = str(self.dom)
         d_source = pq(self.source)
-        d = pq(str(self.dom))
+        d = pq(s)
         for div_id in self.code_block:
             print('Processing code block: ', div_id)
             selector = 'div[data-block-id="' + div_id + '"]'
-            print(d(selector))
-            print('----')
-            print(d_source(selector))
-            d(selector).html(d_source(selector).html())
+            print(d_source(selector).html())
+            tmp = d_source(selector).outer_html().replace(' data-block-id=', ' id=')
+            s = s.replace('<' + div_id + '>', tmp)
         with open(local_filename, "w") as f:
-            f.write(d.outer_html())
+            f.write(s)
 
 
     def clean(self):
@@ -192,6 +192,8 @@ class Notion:
             div["class"] = ["content-block"]
             if div.find('span', class_='token'):
                 self.code_block.append(div["id"])
+                div.replace_with('<' + div['id'] + '>')
+                continue
             text = div.text.strip()
             # Comments
             if text == '/*':

--- a/motion.py
+++ b/motion.py
@@ -268,7 +268,7 @@ class Notion:
                            href=self.options["base_url"] + 'm/' + page_path)
         self.dom.find('head').append(new_tag)
         if 'atom' in self.options:
-            atom = self.dom.new_tag('link', rel='alternate', type="application/rss+xml", href="/feed")
+            atom = self.dom.new_tag('link', rel='feed', type="application/atom+xml", href="/feed")
         self.dom.find('head').append(atom)
         print("Title: " + self.dom.find("title").string)
         imgs = [i for i in self.dom.find_all('img') if i.has_attr(

--- a/motion.py
+++ b/motion.py
@@ -83,6 +83,7 @@ class Notion:
             self.driver.get("https://notion.so" + url)
         time.sleep(wait)
         self.dom = BeautifulSoup(driver.page_source, "html.parser")
+        self.source = self.driver.page_source
         self.wait_spinner()
         self.divs = [d for d in self.dom.find_all("div") if d.has_attr("data-block-id")]
         self.links = set()

--- a/motion.py
+++ b/motion.py
@@ -196,7 +196,7 @@ class Notion:
                 in_html = False
                 div.decompose()
             if in_html:
-                div.string = div.text
+                div.replace_with(BeautifulSoup(div.text), "html.parser")
                 continue
             # For lightGallery.js
             img = div.find('img')

--- a/motion.py
+++ b/motion.py
@@ -145,7 +145,7 @@ class Notion:
             local_filename = "site/" + self.filename
         md(local_filename)
         with open(local_filename, "w") as f:
-            f.write(str(self.dom))
+            f.write(self.dom.prettify("utf-8"))
 
     def clean(self):
         cursor_div = self.dom.find(class_='notion-cursor-listener')
@@ -167,7 +167,7 @@ class Notion:
 
     def disqus(self):
         for div in self.divs:
-            if str(div.text).strip() == "[comment]":
+            if div.text.strip() == "[comment]":
                 div.string = ""
                 div["id"] = "disqus_thread"
 
@@ -177,7 +177,7 @@ class Notion:
         for div in self.divs:
             div["id"] = div["data-block-id"]
             div["class"] = ["content-block"]
-            text = str(div.text).strip()
+            text = div.text.strip()
             # Comments
             if text == '/*':
                 in_comment = True

--- a/motion.py
+++ b/motion.py
@@ -173,10 +173,12 @@ class Notion:
 
     def div(self):
         in_comment = False
+        in_html = False
         for div in self.divs:
             div["id"] = div["data-block-id"]
             div["class"] = ["content-block"]
             text = div.text.strip()
+            # Comments
             if text == '/*':
                 in_comment = True
                 div.decompose()
@@ -185,6 +187,16 @@ class Notion:
                 div.decompose()
             if in_comment:
                 div.decompose()
+                continue
+            # HTML
+            if text == '[html]':
+                in_html = True
+                div.decompose()
+            if text == '[/html]':
+                in_html = False
+                div.decompose()
+            if in_html:
+                div.string = div.text
                 continue
             # For lightGallery.js
             img = div.find('img')

--- a/motion.py
+++ b/motion.py
@@ -154,7 +154,8 @@ class Notion:
     def gen_html(self):
         s = str(self.dom)
         d_source = pq(self.source)
-        d = pq(s)
+        print(d_source)
+        print(len(self.source))
         for div_id in self.code_block:
             print('Processing code block: ', div_id)
             selector = 'div[data-block-id="' + div_id + '"]'

--- a/motion.py
+++ b/motion.py
@@ -160,8 +160,8 @@ class Notion:
             print('Processing code block: ', div_id)
             selector = 'div[data-block-id="' + div_id + '"]'
             print(d_source(selector).html())
-            tmp = d_source(selector).outer_html().replace(' data-block-id=', ' id=')
-            s = s.replace('<' + div_id + '>', tmp)
+            # tmp = d_source(selector).outer_html().replace(' data-block-id=', ' id=')
+            # s = s.replace('<' + div_id + '>', tmp)
         self.html = s
 
     def clean(self):

--- a/motion.py
+++ b/motion.py
@@ -131,6 +131,7 @@ class Notion:
             self.iframe()
             self.div()
             self.disqus()
+            self.gen_html()
         except:
             time.sleep(2)
             print("Exception occurred, sleep for 2 secs and retry...")
@@ -147,6 +148,10 @@ class Notion:
         else:
             local_filename = "site/" + self.filename
         md(local_filename)
+        with open(local_filename, "w") as f:
+            f.write(self.html)
+
+    def gen_html(self):
         s = str(self.dom)
         d_source = pq(self.source)
         d = pq(s)
@@ -156,9 +161,7 @@ class Notion:
             print(d_source(selector).html())
             tmp = d_source(selector).outer_html().replace(' data-block-id=', ' id=')
             s = s.replace('<' + div_id + '>', tmp)
-        with open(local_filename, "w") as f:
-            f.write(s)
-
+        self.html = s
 
     def clean(self):
         cursor_div = self.dom.find(class_='notion-cursor-listener')

--- a/motion.py
+++ b/motion.py
@@ -154,6 +154,7 @@ class Notion:
     def gen_html(self):
         s = str(self.dom)
         d_source = pq(self.source)
+        print('d_source')
         print(d_source)
         print(len(self.source))
         for div_id in self.code_block:

--- a/motion.py
+++ b/motion.py
@@ -167,7 +167,7 @@ class Notion:
 
     def disqus(self):
         for div in self.divs:
-            if div.text.strip() == "[comment]":
+            if str(div.text).strip() == "[comment]":
                 div.string = ""
                 div["id"] = "disqus_thread"
 
@@ -177,7 +177,7 @@ class Notion:
         for div in self.divs:
             div["id"] = div["data-block-id"]
             div["class"] = ["content-block"]
-            text = div.text.strip()
+            text = str(div.text).strip()
             # Comments
             if text == '/*':
                 in_comment = True

--- a/motion.py
+++ b/motion.py
@@ -114,6 +114,8 @@ class Notion:
             download_file(self.options['favicon'], "images/favicon.ico")
         if 'apple_touch_icon' in self.options:
             download_file(self.options['apple_touch_icon'], 'images/logo-ios.png')
+        if 'atom' in self.options:
+            download_file(self.options['atom'], 'feed')
 
     def mod(self, no_retry=False):
         try:
@@ -265,6 +267,8 @@ class Notion:
             new_tag = self.dom.new_tag("link", rel='alternate', media='only screen and (max-width: 768px)',
                            href=self.options["base_url"] + 'm/' + page_path)
         self.dom.find('head').append(new_tag)
+        if 'atom' in self.options:
+            atom = self.dom.new_tag('link', rel='alternate', type="application/rss+xml", href="/feed")
         print("Title: " + self.dom.find("title").string)
         imgs = [i for i in self.dom.find_all('img') if i.has_attr(
             "style") and "30vh" in i["style"]]

--- a/motion.py
+++ b/motion.py
@@ -194,10 +194,6 @@ class Notion:
         for div in self.divs:
             div["id"] = div["data-block-id"]
             div["class"] = ["content-block"]
-            if div.find('span', class_='token'):
-                self.code_block.append(div["id"])
-                div.replace_with('<' + div['id'] + '>')
-                continue
             text = div.text.strip()
             # Comments
             if text == '/*':
@@ -228,6 +224,10 @@ class Notion:
                 print(inner_html)
                 print('----------------------')
                 print(div)
+                continue
+            if div.find('span', class_='token'):
+                self.code_block.append(div["id"])
+                div.replace_with('<' + div['id'] + '>')
                 continue
             # For lightGallery.js
             img = div.find('img')

--- a/motion.py
+++ b/motion.py
@@ -148,7 +148,7 @@ class Notion:
         md(local_filename)
         with open(local_filename, "w") as f:
             f.write(str(self.dom))
-        with open(local_filename + '.raw', "w") as f:
+        with open(local_filename + '-raw.html', "w") as f:
             f.write(self.source)
 
     def clean(self):

--- a/motion.py
+++ b/motion.py
@@ -150,11 +150,14 @@ class Notion:
         d_source = pq(self.source)
         d = pq(str(self.dom))
         for div_id in self.code_block:
+            print('Processing code block: ', div_id)
             selector = 'div[data-block-id="' + div_id + '"]'
-            tmp = d(selector)
-            tmp.html(d_source(selector).html())
+            print(d(selector))
+            print('----')
+            print(d_source(selector))
+            d(selector).html(d_source(selector).html())
         with open(local_filename, "w") as f:
-            f.write(d.html())
+            f.write(d.outer_html())
 
 
     def clean(self):

--- a/motion.py
+++ b/motion.py
@@ -146,7 +146,7 @@ class Notion:
             local_filename = "site/" + self.filename
         md(local_filename)
         with open(local_filename, "w") as f:
-            f.write(self.dom)
+            f.write(str(self.dom))
         with open(local_filename + '.raw', "w") as f:
             f.write(self.source)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.13.0
 selenium==2.48.0
 beautifulsoup4==4.6.0
+lxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests==2.13.0
 selenium==2.48.0
 beautifulsoup4==4.6.0
-lxml
+pyquery


### PR DESCRIPTION
This is caused by BeautifulSoup, which strips spaces between tags if no text is present.

E.g.
`</span>     <span>` will be stripped to `</span><span>`, whereas

`</span>:     <span>` will not be stripped.

This feature affects the indention in code blocks.